### PR TITLE
move dependencies into metadata.rb

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -6,14 +6,3 @@ metadata
 # provided by chef-server so that we can use chef-solo. This removes
 # the necessity to use knife.rb and have a .pem file
 cookbook 'chef-solo-search', :git => 'git://github.com/webcoyote/chef-solo-search.git'
-
-# Use 1.1.2, which is the last version of this cookbook that doesn't
-# have copy-protection checks related to chef-solo
-cookbook 'users', '= 1.1.2'
-
-cookbook 'build-essential'
-cookbook 'curl'
-cookbook 'git'
-cookbook 'openssh'
-cookbook 'sudo'
-cookbook 'zsh'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,3 +6,15 @@ description      "Installs and configures linux-vm"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 
+# Use 1.1.2, which is the last version of this cookbook that doesn't
+# have copy-protection checks related to chef-solo
+cookbook 'users', '= 1.1.2'
+
+cookbook 'build-essential'
+cookbook 'curl'
+cookbook 'git'
+cookbook 'openssh'
+cookbook 'sudo'
+cookbook 'zsh'
+
+cookbook 'chef-solo-search'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,13 +8,13 @@ version          "0.1.0"
 
 # Use 1.1.2, which is the last version of this cookbook that doesn't
 # have copy-protection checks related to chef-solo
-cookbook 'users', '= 1.1.2'
+depends 'users', '= 1.1.2'
 
-cookbook 'build-essential'
-cookbook 'curl'
-cookbook 'git'
-cookbook 'openssh'
-cookbook 'sudo'
-cookbook 'zsh'
+depends 'build-essential'
+depends 'curl'
+depends 'git'
+depends 'openssh'
+depends 'sudo'
+depends 'zsh'
 
-cookbook 'chef-solo-search'
+depends 'chef-solo-search'


### PR DESCRIPTION
When iterating a Cookbook the `metadata.rb` file should be the authoritative source for dependencies. It's always best to put all of your dependencies in there much like you would for your RubyGems in a gemspec file.

It's a good idea to use the `Berksfile` to overwrite the "location" of a Cookbook. It's also a good idea to put any development or test dependencies in the `Berksfile` which you wish your developers / testers to pull down but you do not want an end user to get. This is possible because end users will not resolve the Berksfile - they'll just resolve the metadata.rb of a dependency.

This is the same behavior of the Gemfile and Gemspec in Rubygems
