### PR TITLE
Added ubuntu support to grub timeout change.

### DIFF
--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -66,8 +66,15 @@ search("users", "groups:sysadmin NOT action:remove") do |u|
 
 end
 
-execute "set boot timeout=0" do
-  user 'root'
-  command "sed --in-place=.bak -r -e 's/timeout=[0-9]+/timeout=0/' /boot/grub/grub.conf"
+if platform?("ubuntu")
+  execute "set boot timeout to 0" do
+    user 'root'
+    command "sed --in-place=.bak -r -e 's/GRUB_TIMEOUT=[0-9]+/GRUB_TIMEOUT=0/' /etc/default/grub && update-grub"
+    not_if "grep -q 'GRUB_TIMEOUT=0' /etc/default/grub"
+  end
+else
+  execute "set boot timeout=0" do
+    user 'root'
+    command "sed --in-place=.bak -r -e 's/timeout=[0-9]+/timeout=0/' /boot/grub/grub.conf"
+  end
 end
-

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -66,8 +66,15 @@ search("users", "groups:sysadmin NOT action:remove") do |u|
 
 end
 
-execute "set boot timeout=0" do
-  user 'root'
-  command "sed --in-place=.bak -r -e 's/timeout=[0-9]+/timeout=0/' /boot/grub/grub.conf"
+if platform?("ubuntu")
+  execute "set boot timeout to 0" do
+	user 'root'
+	command "sed --in-place=.bak -r -e 's/GRUB_TIMEOUT=[0-9]+/GRUB_TIMEOUT=0/' /etc/default/grub && update-grub"
+	not_if "grep -q 'GRUB_TIMEOUT=0' /etc/default/grub"
+  end
+else
+  execute "set boot timeout=0" do
+	user 'root'
+	command "sed --in-place=.bak -r -e 's/timeout=[0-9]+/timeout=0/' /boot/grub/grub.conf"
+  end
 end
-

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -66,15 +66,8 @@ search("users", "groups:sysadmin NOT action:remove") do |u|
 
 end
 
-if platform?("ubuntu")
-  execute "set boot timeout to 0" do
-	user 'root'
-	command "sed --in-place=.bak -r -e 's/GRUB_TIMEOUT=[0-9]+/GRUB_TIMEOUT=0/' /etc/default/grub && update-grub"
-	not_if "grep -q 'GRUB_TIMEOUT=0' /etc/default/grub"
-  end
-else
-  execute "set boot timeout=0" do
-	user 'root'
-	command "sed --in-place=.bak -r -e 's/timeout=[0-9]+/timeout=0/' /boot/grub/grub.conf"
-  end
+execute "set boot timeout=0" do
+  user 'root'
+  command "sed --in-place=.bak -r -e 's/timeout=[0-9]+/timeout=0/' /boot/grub/grub.conf"
 end
+


### PR DESCRIPTION
Hey Pat, 

I started using this repository a couple of weeks ago and wanted to help out.

I am not 100 percent sure the timeout should live users.rb since it is platform specific. It seems like it should live in the desktop_rhel recipe and I should submit a pull request with a desktop_ubuntu recipe where my addition would live. What do you think? 
