### PR TITLE
Pin vagrant version on cinst command

### DIFF
--- a/INSTALL.ps1
+++ b/INSTALL.ps1
@@ -200,7 +200,9 @@ function InstallGit () {
 # Vagrant
 #-----------------------------------------------
 function InstallVagrant () {
-  cinst vagrant
+  # We need to pin a version of vagrant that plays nice with the Berkshelf
+  # plugin.
+  cinst vagrant -version 1.4.3
 }
 
 function InstallVagrantPlugins () {
@@ -264,7 +266,7 @@ function MakeVirtualMachine () {
   # when resizing its window on the host system.
 
   # Switch to graphics mode
-  Exec { &$vagrantCmd ssh -c "sudo /sbin/init 5" }
+  Exec { &$vagrantCmd ssh -c "sudo /sbin/init 5" -- -n -T }
 
   # Update VirtualBox guest additions
   write-host "Updating VirtualBox guest additions"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Login with the user name: **vagrant**
 
 Here are the features of the Linux virtual machine you will create (all configurable):
 
-* Linux [CentOS](https://www.centos.org/) 6.3 operating system
+* Linux [Ubuntu](http://www.ubuntu.com/) 12.04 operating system ("precise")
 * [Gnome](http://www.gnome.org/) desktop
 * [Firefox](http://www.mozilla.org/en-US/firefox/new/) browser
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,6 @@ Vagrant.configure("2") do |config|
   # Configure plugins
   config.omnibus.chef_version = :latest
   config.berkshelf.enabled = true
-  config.omnibus.chef_version = :latest
 
   # Run this command manually after XWindows is installed:
   # vagrant vbguest --do install


### PR DESCRIPTION
Vagrant ~1.5 is having a gem fight with vagrant-berkshelf. While OpsCode and HashiCorp solve the problem, I propose we pin the version of Vagrant.

Also passing additional args to vagrant ssh via -- as suggested here: (https://groups.google.com/forum/#!topic/vagrant-up/yZC4--9Ygls) solved a problem I was having with setting init 5 automatically.

I am also having an issue where --auto-reboot on the vagrant vbguest command doesn't execute because the guest package apparently fails:
An error occurred during installation of VirtualBox Guest Additions 4.3.8. Some functionality may not work as intended.
In most cases it is OK that the "Window System drivers" installation failed.
